### PR TITLE
Fix despliegue Coolify: MySQL 8.4, healthcheck y CORS

### DIFF
--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -3,7 +3,6 @@ version: "3.9"
 services:
   db:
     image: mysql:8.4
-    command: --default-authentication-plugin=mysql_native_password
     restart: unless-stopped
     environment:
       MYSQL_ROOT_PASSWORD: IsturgiRoot_2026_DB94
@@ -12,6 +11,12 @@ services:
       MYSQL_PASSWORD: IsturgiApp_2026_User57
     volumes:
       - mysql_data_v2:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-pIsturgiRoot_2026_DB94"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
 
   backend:
     build:
@@ -19,13 +24,15 @@ services:
       dockerfile: Dockerfile
     restart: unless-stopped
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       DB_HOST: db
       DB_PORT: "3306"
       DB_NAME: tenis_isturgi
       DB_USER: tenis_user
       DB_PASSWORD: IsturgiApp_2026_User57
+      CORS_ALLOWED_ORIGINS: https://isfen1z2d9wj89ja8xqqe9ac.51.210.104.106.sslip.io,http://isfen1z2d9wj89ja8xqqe9ac.51.210.104.106.sslip.io
 
   frontend:
     build:

--- a/spring-backend/Dockerfile
+++ b/spring-backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.9.11-eclipse-temurin-21 AS builder
+FROM maven:3.9.9-eclipse-temurin-21 AS builder
 WORKDIR /app
 
 COPY pom.xml .


### PR DESCRIPTION
## Cambios

Correcciones necesarias para que el despliegue en Coolify funcione correctamente.

### Problemas resueltos

- **MySQL 8.4**: eliminado `--default-authentication-plugin=mysql_native_password` que fue removido en MySQL 8.4 y causaba que el contenedor de base de datos no arrancase.
- **Orden de arranque**: añadido `healthcheck` al servicio `db` y `condition: service_healthy` en el `backend`, evitando que Spring Boot intente conectarse antes de que MySQL esté listo.
- **CORS en producción**: añadida variable de entorno `CORS_ALLOWED_ORIGINS` al backend con la URL pública, ya que sin ella se usaba el valor por defecto `localhost:5173` y todas las peticiones del frontend eran bloqueadas.
- **Maven**: corregida la versión de la imagen Docker de `3.9.11` (no existe en Docker Hub) a `3.9.9`.

### Archivos modificados
- `docker-compose.coolify.yml`
- `spring-backend/Dockerfile`