### PR TITLE
Fix compose: eliminar servicio db duplicado y usar variables de Coolify

### DIFF
--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -1,33 +1,13 @@
 version: "3.9"
 
 services:
-  db:
-    image: mysql:8.4
-    restart: unless-stopped
-    environment:
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
-      MYSQL_DATABASE: ${DB_NAME}
-      MYSQL_USER: ${DB_USER}
-      MYSQL_PASSWORD: ${DB_PASSWORD}
-    volumes:
-      - mysql_data_v2:/var/lib/mysql
-    healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD}"]
-      interval: 10s
-      timeout: 5s
-      retries: 10
-      start_period: 30s
-
   backend:
     build:
       context: ./spring-backend
       dockerfile: Dockerfile
     restart: unless-stopped
-    depends_on:
-      db:
-        condition: service_healthy
     environment:
-      DB_HOST: db
+      DB_HOST: ${DB_HOST}
       DB_PORT: "3306"
       DB_NAME: ${DB_NAME}
       DB_USER: ${DB_USER}
@@ -50,6 +30,3 @@ services:
     restart: unless-stopped
     depends_on:
       - backend
-
-volumes:
-  mysql_data_v2:

--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -5,14 +5,14 @@ services:
     image: mysql:8.4
     restart: unless-stopped
     environment:
-      MYSQL_ROOT_PASSWORD: IsturgiRoot_2026_DB94
-      MYSQL_DATABASE: tenis_isturgi
-      MYSQL_USER: tenis_user
-      MYSQL_PASSWORD: IsturgiApp_2026_User57
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${DB_NAME}
+      MYSQL_USER: ${DB_USER}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
     volumes:
       - mysql_data_v2:/var/lib/mysql
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-pIsturgiRoot_2026_DB94"]
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD}"]
       interval: 10s
       timeout: 5s
       retries: 10
@@ -29,24 +29,24 @@ services:
     environment:
       DB_HOST: db
       DB_PORT: "3306"
-      DB_NAME: tenis_isturgi
-      DB_USER: tenis_user
-      DB_PASSWORD: IsturgiApp_2026_User57
-      CORS_ALLOWED_ORIGINS: https://isfen1z2d9wj89ja8xqqe9ac.51.210.104.106.sslip.io,http://isfen1z2d9wj89ja8xqqe9ac.51.210.104.106.sslip.io
+      DB_NAME: ${DB_NAME}
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
+      CORS_ALLOWED_ORIGINS: ${SERVICE_URL_FRONTEND}
 
   frontend:
     build:
       context: ./frontend
       dockerfile: Dockerfile
       args:
-        VITE_API_BASE_URL: http://isfen1z2d9wj89ja8xqqe9ac.51.210.104.106.sslip.io
-        VITE_FIREBASE_API_KEY: AIzaSyBxsLRoR_7obGhweEWhaW43XVNH9PMYJfA
-        VITE_FIREBASE_AUTH_DOMAIN: tenis-isturgi.firebaseapp.com
-        VITE_FIREBASE_PROJECT_ID: tenis-isturgi
-        VITE_FIREBASE_STORAGE_BUCKET: tenis-isturgi.firebasestorage.app
-        VITE_FIREBASE_MESSAGING_SENDER_ID: 707348941864
-        VITE_FIREBASE_APP_ID: 1:707348941864:web:d54fcecfb0677a6851791d
-        VITE_ADMIN_EMAILS: admin@isturgi.com
+        VITE_API_BASE_URL: ${SERVICE_URL_BACKEND}
+        VITE_FIREBASE_API_KEY: ${VITE_FIREBASE_API_KEY}
+        VITE_FIREBASE_AUTH_DOMAIN: ${VITE_FIREBASE_AUTH_DOMAIN}
+        VITE_FIREBASE_PROJECT_ID: ${VITE_FIREBASE_PROJECT_ID}
+        VITE_FIREBASE_STORAGE_BUCKET: ${VITE_FIREBASE_STORAGE_BUCKET}
+        VITE_FIREBASE_MESSAGING_SENDER_ID: ${VITE_FIREBASE_MESSAGING_SENDER_ID}
+        VITE_FIREBASE_APP_ID: ${VITE_FIREBASE_APP_ID}
+        VITE_ADMIN_EMAILS: ${VITE_ADMIN_EMAILS}
     restart: unless-stopped
     depends_on:
       - backend


### PR DESCRIPTION
## Cambios

Continuación de la PR #33. Estos commits se hicieron después del merge anterior.

### Problemas resueltos

- **Servicio `db` eliminado del compose**: Coolify ya tiene una base de datos MySQL gestionada de forma independiente (`tenis_isturgi_db`). Mantener el servicio `db` en el compose causaba que se levantase un segundo contenedor MySQL que fallaba el healthcheck bloqueando todo el despliegue.
- **Variables de entorno dinámicas**: todos los valores hardcodeados (contraseñas, dominios) se han reemplazado por variables `${VAR}` que Coolify inyecta automáticamente (`SERVICE_URL_FRONTEND`, `SERVICE_URL_BACKEND`, `DB_HOST`, `DB_USER`, `DB_PASSWORD`, etc.).

### Archivos modificados
- `docker-compose.coolify.yml`